### PR TITLE
Bugfix/retry failed queries

### DIFF
--- a/mirror.py
+++ b/mirror.py
@@ -42,7 +42,7 @@ def get_games():
     global game_data
     print("Fetching games")
 
-    games_uri = "https://api2.blaseball.com/seasons/cd1b6714-f4de-4dfc-a030-851b3459d8d1x/games"
+    games_uri = "https://api2.blaseball.com/seasons/cd1b6714-f4de-4dfc-a030-851b3459d8d1/games"
     for _ in range(REQUEST_RETRIES):
         games_response = requests.get(games_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
         if games_response.status_code == 500:

--- a/mirror.py
+++ b/mirror.py
@@ -6,6 +6,10 @@ import time
 from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask, jsonify
 
+REQUEST_DELAY = 0.1
+REQUEST_RETRIES = 3
+REQUEST_RETRY_DELAY = 5
+
 game_data = {}
 
 def set_auth_var():
@@ -37,16 +41,24 @@ def set_auth_var():
 def get_games():
     global game_data
     print("Fetching games")
-    games_uri = "https://api2.blaseball.com/seasons/cd1b6714-f4de-4dfc-a030-851b3459d8d1/games"
-    games_response = requests.get(games_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
 
-    game_data = games_response.json()
+    games_uri = "https://api2.blaseball.com/seasons/cd1b6714-f4de-4dfc-a030-851b3459d8d1x/games"
+    for _ in range(REQUEST_RETRIES):
+        games_response = requests.get(games_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
+        if games_response.status_code == 500:
+            print("Games request failed - retrying")
+            time.sleep(REQUEST_RETRY_DELAY)
+        else:
+            game_data = games_response.json()
 
-    for game in game_data:
-        del game["gameEventBatches"]
+            for game in game_data:
+                del game["gameEventBatches"]
 
-    with open('games.json', 'w') as f:
-        json.dump(game_data, f)
+            with open('games.json', 'w') as f:
+                json.dump(game_data, f)
+            break
+    else:
+        print("Games request failed all retries - Not updating")
 
 def get_sim():
     ''' Get and set global sim data (season, day, etc)'''
@@ -55,14 +67,21 @@ def get_sim():
     global sim_data
     print("Fetching sim")
     sim_uri = "https://api2.blaseball.com/sim/"
-    sim_response = requests.get(sim_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
+    for _ in range(REQUEST_RETRIES):
+        sim_response = requests.get(sim_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
+        if sim_response.status_code == 500:
+            print("Sim request failed - retrying")
+            time.sleep(REQUEST_RETRY_DELAY)
+        else:
+            sim_data = sim_response.json()
+            season_id = sim_data['simData']['currentSeasonId']
+            day = sim_data['simData']['currentDay']
 
-    sim_data = sim_response.json()
-    season_id = sim_data['simData']['currentSeasonId']
-    day = sim_data['simData']['currentDay']
-
-    with open('sim.json', 'w') as f:
-        json.dump(sim_data, f)
+            with open('sim.json', 'w') as f:
+                json.dump(sim_data, f)
+            break
+    else:
+        print("Sim request failed all retries - Not updating")
 
 def get_teams():
     global teams_data
@@ -73,24 +92,33 @@ def get_teams():
         divisions.extend(subleague['divisions'])
 
     teams_uri = f"https://api2.blaseball.com/seasons/{season_id}/days/{day}/teams"
-    teams_response = requests.get(teams_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
+    # There has to be a better way than this
+    for _ in range(REQUEST_RETRIES):
+        teams_response = requests.get(teams_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
+        if teams_response.status_code == 500:
+            print(f"Teams request failed - retrying")
+            time.sleep(REQUEST_RETRY_DELAY)
+        else:
+            teams_response_data = teams_response.json()
+            temp_teams_data = []
 
-    teams_reponse_data = teams_response.json()
+            for division in divisions:
+                division_teams = teams_response_data[division['id']]
+                temp_teams_data.extend(division_teams)
 
-    temp_teams_data = []
-    for division in divisions:
-        division_teams = teams_reponse_data[division['id']]
-        temp_teams_data.extend(division_teams)
+            teams_data = temp_teams_data
 
-    teams_data = temp_teams_data
+            with open('teams.json', 'w') as f:
+                json.dump(teams_data, f)
+            break
+    else:
+        print("Teams request failed all retries - not updating")
+    # If the retries fail, teams_data just doesn't get updated
 
-    with open('teams.json', 'w') as f:
-        json.dump(teams_data, f)
 def get_players():
     global players_data
     print("Fetching players")
 
-    delay = 0.1
     roster_players = []
     for team in teams_data:
         roster_players.extend(team['roster'])
@@ -101,11 +129,19 @@ def get_players():
             print(f'{len(temp_players_data)} of {len(roster_players)}...')
 
         player_uri = f"https://api2.blaseball.com/seasons/{season_id}/days/{day}/players/{player['id']}"
-        player_response = requests.get(player_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
 
-        player_response_data = player_response.json()
-        temp_players_data.append(player_response_data)
-        time.sleep(delay)
+        # There's probably a better way to do this
+        for _ in range(REQUEST_RETRIES):
+            player_response = requests.get(player_uri, cookies=requests.utils.cookiejar_from_dict(json.loads(os.environ.get("BB_COOKIES"))))
+            if player_response.status_code == 500:
+                print(f"{player['id']} Player request failed - retrying")
+                time.sleep(REQUEST_RETRY_DELAY)
+            else:
+                player_response_data = player_response.json()
+                temp_players_data.append(player_response_data)
+                break
+        # If it doesn't get a good response, don't add player to temp_player_data
+        time.sleep(REQUEST_DELAY)
 
     players_data = temp_players_data
 


### PR DESCRIPTION
Added retry logic to all requests (current 3 attempts, 5 seconds between).
For Sim, Games, and Teams, if it fails all it's retries, it'll just leave the most recent data.
For Players, that player will not be in the update.

Tested as well as I could through debugging.
On my most recent run, locally, it did log a retry on a player, so it seems to be working.